### PR TITLE
Fix f-string errors in MCP order processor

### DIFF
--- a/services/mcp_order_processor.py
+++ b/services/mcp_order_processor.py
@@ -66,19 +66,14 @@ class MCPOrderProcessor:
                 )
             except requests.exceptions.HTTPError as e:
                 self.logger.error(
-                    f"HTTP error on {url}: {e} - {
-                        getattr(
-                            e.response,
-                            'text',
-                            '')}"
+                    f"HTTP error on {url}: {e} - {getattr(e.response, 'text', '')}"
                 )
                 break  # Don't retry on HTTP errors
             except Exception as e:
                 self.logger.error(f"Unexpected error on {url}: {e}")
             time.sleep(2**attempt)
         self.logger.error(
-            f"Failed to POST to {url} after {
-                self.max_retries} attempts."
+            f"Failed to POST to {url} after {self.max_retries} attempts."
         )
         return None
 


### PR DESCRIPTION
## Summary
- fix f-string formatting in `_post_with_retry` to properly log HTTP and retry errors

## Testing
- `PYTHONPATH=. pytest -q` *(fails: SyntaxError in backup_original_structure/test_api_integration.py line 58, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688dc6b26034832fa8ead20bb2250c93